### PR TITLE
update dse driver version to 1.6.7

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 scalacOptions += "-target:jvm-1.8"
 
-libraryDependencies += "com.datastax.dse"             %  "dse-java-driver-core"     % "1.5.1"
-libraryDependencies += "com.datastax.dse"             %  "dse-java-driver-graph"    % "1.5.1"
+libraryDependencies += "com.datastax.dse"             %  "dse-java-driver-core"     % "1.6.7"
+libraryDependencies += "com.datastax.dse"             %  "dse-java-driver-graph"    % "1.6.7"
 libraryDependencies += "com.github.nscala-time"       %% "nscala-time"              % "2.18.0"
 libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala"     % "2.9.1"
 libraryDependencies += "org.hdrhistogram"             %  "HdrHistogram"             % "2.1.10"


### PR DESCRIPTION
1.6.7 has tinkerpop 3.3.3, which fixes https://datastax.jira.com/browse/DSP-15686

(how should this be tested?)