### PR TITLE
Truncate latencies higher than the maximum allowed value

### DIFF
--- a/src/main/scala/com/datastax/gatling/plugin/metrics/HistogramLogConfig.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/metrics/HistogramLogConfig.scala
@@ -68,4 +68,6 @@ case class HistogramLogConfig(enabled: Boolean,
 
 case class HistogramCategoryConfig(enabled: Boolean,
                                    highestValue: Long,
-                                   resolution: Int)
+                                   resolution: Int) {
+  val maximumLatencyVerifier = new MaximumLatencyVerifier(highestValue)
+}

--- a/src/main/scala/com/datastax/gatling/plugin/metrics/HistogramLogger.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/metrics/HistogramLogger.scala
@@ -193,10 +193,13 @@ class PerSecondHistogram(val hgrmPath: Path,
   override def close(): Unit =
     writer.close()
 
-  def recordLatency(timeSec: Long, latencyNanos: Long): Unit =
+  def recordLatency(timeSec: Long, latencyNanos: Long): Unit = {
+    val maybeCappedcappedLatency =
+      config.maximumLatencyVerifier.maybeTruncateAndLog(latencyNanos)
     histograms
       .computeIfAbsent(timeSec, _ => newHistogram())
-      .recordValue(latencyNanos)
+      .recordValue(maybeCappedcappedLatency)
+  }
 
   def writeUntil(maxTimeStampSec: Long) {
     val histogramsToWrite = histograms.headMap(maxTimeStampSec)

--- a/src/main/scala/com/datastax/gatling/plugin/metrics/MaximumLatencyVerifier.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/metrics/MaximumLatencyVerifier.scala
@@ -1,0 +1,21 @@
+package com.datastax.gatling.plugin.metrics
+
+import com.datastax.gatling.plugin.utils.ExponentialLogger
+
+class MaximumLatencyVerifier(val maximumAllowedLatency: Long)
+  extends ExponentialLogger(1, 10) {
+
+  def maybeTruncateAndLog(latencyNanos: Long): Long = {
+    if (latencyNanos > maximumAllowedLatency) {
+      tick()
+      maximumAllowedLatency
+    } else {
+      latencyNanos
+    }
+  }
+
+  override def logTriggered(): Unit =
+    logger.error("Attempt to record a latency higher than the " +
+      "maximum allowed ({}ns).  Recorded latency will be truncated.  Please " +
+      "adjust highestTrackableValue in dse-plugin.conf", maximumAllowedLatency)
+}

--- a/src/main/scala/com/datastax/gatling/plugin/request/CqlRequestAction.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/request/CqlRequestAction.scala
@@ -69,8 +69,6 @@ class CqlRequestAction(val name: String,
       ThroughputVerifier.checkForGatlingOverloading(session, gatlingTimingSource)
       GatlingResponseTime.startedByGatling(session, gatlingTimingSource)
     }
-
-    ThroughputVerifier.checkForGatlingOverloading(session, gatlingTimingSource)
     val stmt = dseAttributes.statement.buildFromSession(session)
 
     stmt.onFailure(err => {

--- a/src/main/scala/com/datastax/gatling/plugin/request/CqlRequestAction.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/request/CqlRequestAction.scala
@@ -6,17 +6,17 @@
 
 package com.datastax.gatling.plugin.request
 
+import java.lang.Boolean
 import java.util.UUID
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit.MICROSECONDS
-import java.util.concurrent.{ExecutorService, TimeUnit}
 
 import akka.actor.ActorSystem
 import com.datastax.gatling.plugin.DseProtocol
 import com.datastax.gatling.plugin.metrics.MetricsLogger
 import com.datastax.gatling.plugin.model.DseCqlAttributes
 import com.datastax.gatling.plugin.response.CqlResponseHandler
-import com.datastax.gatling.plugin.utils.{FutureUtils, GatlingTimingSource, ResponseTime}
-import com.google.common.util.concurrent.MoreExecutors
+import com.datastax.gatling.plugin.utils._
 import io.gatling.commons.stats.KO
 import io.gatling.core.action.{Action, ExitableAction}
 import io.gatling.core.session.Session
@@ -61,11 +61,20 @@ class CqlRequestAction(val name: String,
   }
 
   def sendQuery(session: Session): Unit = {
+    val enableCO = Boolean.getBoolean("gatling.dse.plugin.enable_coordinated_omission")
+    val responseTimeBuilder: ResponseTimeBuilder = if (enableCO) {
+      // The throughput checker is useless in CO affected scenarios since throughput is not known in advance
+      COAffectedResponseTime.startingAt(System.nanoTime())
+    } else {
+      ThroughputVerifier.checkForGatlingOverloading(session, gatlingTimingSource)
+      GatlingResponseTime.startedByGatling(session, gatlingTimingSource)
+    }
+
     ThroughputVerifier.checkForGatlingOverloading(session, gatlingTimingSource)
     val stmt = dseAttributes.statement.buildFromSession(session)
 
     stmt.onFailure(err => {
-      val responseTime: ResponseTime = ResponseTime(session, gatlingTimingSource)
+      val responseTime: ResponseTime = responseTimeBuilder.build()
       val logUuid = UUID.randomUUID.toString
       val tagString = if (session.groupHierarchy.nonEmpty) session.groupHierarchy.mkString("/") + "/" + dseAttributes.tag else dseAttributes.tag
 
@@ -77,8 +86,6 @@ class CqlRequestAction(val name: String,
     })
 
     stmt.onSuccess({ stmt =>
-      val responseTime = ResponseTime(session, gatlingTimingSource)
-
       // global options
       dseAttributes.cl.map(stmt.setConsistencyLevel)
       dseAttributes.userOrRole.map(stmt.executingAs)
@@ -96,7 +103,7 @@ class CqlRequestAction(val name: String,
         stmt.enableTracing
       }
 
-      val responseHandler = new CqlResponseHandler(next, session, system, statsEngine, responseTime, stmt, dseAttributes, metricsLogger)
+      val responseHandler = new CqlResponseHandler(next, session, system, statsEngine, responseTimeBuilder, stmt, dseAttributes, metricsLogger)
       implicit val sameThreadExecutionContext: ExecutionContextExecutor = ExecutionContext.fromExecutorService(dseExecutorService)
       FutureUtils
         .toScalaFuture(protocol.session.executeAsync(stmt))

--- a/src/main/scala/com/datastax/gatling/plugin/request/CqlRequestAction.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/request/CqlRequestAction.scala
@@ -61,7 +61,7 @@ class CqlRequestAction(val name: String,
   }
 
   def sendQuery(session: Session): Unit = {
-    val enableCO = Boolean.getBoolean("gatling.dse.plugin.enable_coordinated_omission")
+    val enableCO = Boolean.getBoolean("gatling.dse.plugin.measure_service_time")
     val responseTimeBuilder: ResponseTimeBuilder = if (enableCO) {
       // The throughput checker is useless in CO affected scenarios since throughput is not known in advance
       COAffectedResponseTime.startingAt(System.nanoTime())

--- a/src/main/scala/com/datastax/gatling/plugin/request/GraphRequestAction.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/request/GraphRequestAction.scala
@@ -61,7 +61,7 @@ class GraphRequestAction(val name: String,
 
 
   def sendQuery(session: Session): Unit = {
-    val enableCO = Boolean.getBoolean("gatling.dse.plugin.enable_coordinated_omission")
+    val enableCO = Boolean.getBoolean("gatling.dse.plugin.measure_service_time")
     val responseTimeBuilder: ResponseTimeBuilder = if (enableCO) {
       // The throughput checker is useless in CO affected scenarios since throughput is not known in advance
       COAffectedResponseTime.startingAt(System.nanoTime())

--- a/src/main/scala/com/datastax/gatling/plugin/request/GraphRequestAction.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/request/GraphRequestAction.scala
@@ -6,16 +6,17 @@
 
 package com.datastax.gatling.plugin.request
 
+import java.lang.Boolean
 import java.util.UUID
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit.MICROSECONDS
-import java.util.concurrent.{ExecutorService, TimeUnit}
 
 import akka.actor.ActorSystem
 import com.datastax.gatling.plugin.DseProtocol
 import com.datastax.gatling.plugin.metrics.MetricsLogger
 import com.datastax.gatling.plugin.model.DseGraphAttributes
 import com.datastax.gatling.plugin.response.GraphResponseHandler
-import com.datastax.gatling.plugin.utils.{FutureUtils, GatlingTimingSource, ResponseTime}
+import com.datastax.gatling.plugin.utils._
 import io.gatling.commons.stats.KO
 import io.gatling.core.action.{Action, ExitableAction}
 import io.gatling.core.session.Session
@@ -60,11 +61,18 @@ class GraphRequestAction(val name: String,
 
 
   def sendQuery(session: Session): Unit = {
-    ThroughputVerifier.checkForGatlingOverloading(session, gatlingTimingSource)
+    val enableCO = Boolean.getBoolean("gatling.dse.plugin.enable_coordinated_omission")
+    val responseTimeBuilder: ResponseTimeBuilder = if (enableCO) {
+      // The throughput checker is useless in CO affected scenarios since throughput is not known in advance
+      COAffectedResponseTime.startingAt(System.nanoTime())
+    } else {
+      ThroughputVerifier.checkForGatlingOverloading(session, gatlingTimingSource)
+      GatlingResponseTime.startedByGatling(session, gatlingTimingSource)
+    }
     val stmt = dseAttributes.statement.buildFromSession(session)
 
     stmt.onFailure(err => {
-      val responseTime = ResponseTime(session, gatlingTimingSource)
+      val responseTime = responseTimeBuilder.build()
       val logUuid = UUID.randomUUID.toString
       val tagString = if (session.groupHierarchy.nonEmpty) session.groupHierarchy.mkString("/") + "/" + dseAttributes.tag else dseAttributes.tag
 
@@ -76,7 +84,6 @@ class GraphRequestAction(val name: String,
     })
 
     stmt.onSuccess({ gStmt =>
-      val responseTime = ResponseTime(session, gatlingTimingSource)
       // global options
       dseAttributes.cl.map(gStmt.setConsistencyLevel)
       dseAttributes.defaultTimestamp.map(gStmt.setDefaultTimestamp)
@@ -102,7 +109,7 @@ class GraphRequestAction(val name: String,
         gStmt.setSystemQuery()
       }
 
-      val responseHandler = new GraphResponseHandler(next, session, system, statsEngine, responseTime, gStmt, dseAttributes, metricsLogger)
+      val responseHandler = new GraphResponseHandler(next, session, system, statsEngine, responseTimeBuilder, gStmt, dseAttributes, metricsLogger)
       implicit val sameThreadExecutionContext: ExecutionContextExecutor = ExecutionContext.fromExecutorService(dseExecutorService)
       FutureUtils
         .toScalaFuture(protocol.session.executeGraphAsync(gStmt))

--- a/src/main/scala/com/datastax/gatling/plugin/request/ThroughputVerifier.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/request/ThroughputVerifier.scala
@@ -6,12 +6,9 @@
 
 package com.datastax.gatling.plugin.request
 
-import java.util.concurrent.Semaphore
 import java.util.concurrent.TimeUnit.{MILLISECONDS, NANOSECONDS}
-import java.util.concurrent.atomic.AtomicLong
 
-import com.datastax.gatling.plugin.utils.GatlingTimingSource
-import com.typesafe.scalalogging.StrictLogging
+import com.datastax.gatling.plugin.utils.{ExponentialLogger, GatlingTimingSource}
 import io.gatling.core.session.Session
 
 /**
@@ -32,30 +29,23 @@ import io.gatling.core.session.Session
   *
   * (3) Some bad Akka tuning.
   */
-object ThroughputVerifier extends StrictLogging {
+object ThroughputVerifier extends ExponentialLogger(1000, 2) {
   private val warningThresholdInSec = 10
-  private val warningSemaphore = new Semaphore(1)
-  private val spottedDelays = new AtomicLong()
-  @volatile private var nextWarning = 1000
 
   def checkForGatlingOverloading(session: Session,
                                  timeSource: GatlingTimingSource): Unit = {
     val userStartTimeSec = MILLISECONDS.toSeconds(session.startDate)
     val currentTimeSec = NANOSECONDS.toSeconds(timeSource.currentTimeNanos())
     if (currentTimeSec - userStartTimeSec > warningThresholdInSec) {
-      val spotted = spottedDelays.incrementAndGet()
-      if (spotted > nextWarning) {
-        if (warningSemaphore.tryAcquire()) {
-          logger.error("Gatling plugin cannot keep up with the " +
-            "target injection rate. {} queries have been sent more than {}s " +
-            "after they expected send time.  This can be caused by the query " +
-            "preparation taking too long.  Check the CPU usage on the " +
-            "Gatling machine and the feeders code.  Reducing the target " +
-            "injection rate may also help.", spotted, warningThresholdInSec)
-          nextWarning *= 2
-          warningSemaphore.release()
-        }
-      }
+      tick()
     }
   }
+
+  override def logTriggered(): Unit =
+    logger.error("Gatling plugin cannot keep up with the " +
+      "target injection rate. {} queries have been sent more than {}s " +
+      "after they expected send time.  This can be caused by the query " +
+      "preparation taking too long.  Check the CPU usage on the " +
+      "Gatling machine and the feeders code.  Reducing the target " +
+      "injection rate may also help.", ticksSoFar(), warningThresholdInSec)
 }

--- a/src/main/scala/com/datastax/gatling/plugin/utils/ExponentialLogger.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/utils/ExponentialLogger.scala
@@ -1,0 +1,50 @@
+package com.datastax.gatling.plugin.utils
+
+import java.util.concurrent.Semaphore
+import java.util.concurrent.atomic.AtomicLong
+
+import com.typesafe.scalalogging.StrictLogging
+
+/**
+  * Special kind of logger made for repetitive messages that do not add a lot of
+  * value over time.
+  *
+  * This logger keeps track of the number of times it has been ticked.  Whenever
+  * it crosses its initial threshold, the {{logTriggered()}} method is called
+  * and the threshold is multiplied by {{decayFactor}}.
+  *
+  * This results in logs being printed very often during the first occurrences
+  * of a monitored corner case, but less the more that corner case happens.
+  *
+  * A Semaphore of 1 permit is used to make sure that the threshold is
+  * atomically updated.  Instead of using {{Semaphore.acquire()}}, the method
+  * {{Semaphore.tryAcquire()}} is used so that there is no contention of this
+  * component.
+  *
+  * @param initialThreshold the initial number of occurrences of a corner case
+  *                         before {{logTriggered()}} is called
+  * @param decayFactor      the decaying factor to use when the threshold is
+  *                         updated
+  */
+abstract class ExponentialLogger(val initialThreshold: Int,
+                                 val decayFactor: Int = 2)
+  extends StrictLogging {
+  private val semaphore = new Semaphore(1)
+  private val ticksCounter = new AtomicLong()
+  @volatile private var nextLogAtTicks = initialThreshold
+
+  def logTriggered(): Unit
+
+  def ticksSoFar(): Long = ticksCounter.get()
+
+  def tick(): Unit = {
+    val newTicksSoFar = ticksCounter.incrementAndGet()
+    if (newTicksSoFar > nextLogAtTicks) {
+      if (semaphore.tryAcquire()) {
+        logTriggered()
+        nextLogAtTicks *= decayFactor
+        semaphore.release()
+      }
+    }
+  }
+}

--- a/src/main/scala/com/datastax/gatling/plugin/utils/ResponseTime.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/utils/ResponseTime.scala
@@ -18,7 +18,7 @@ trait ResponseTime {
 
   def toGatlingResponseTimings: ResponseTimings
 
-  def startTimeInSeconds: Long
+  def startTimeIn(targetTimeUnit: TimeUnit): Long
 }
 
 trait ResponseTimeBuilder {
@@ -53,8 +53,8 @@ case class GatlingResponseTime(session: Session, timingSource: TimingSource)
   override def latencyIn(targetTimeUnit: TimeUnit): Long =
     targetTimeUnit.convert(latencyInNanos, NANOSECONDS)
 
-  override def startTimeInSeconds: Long =
-    MILLISECONDS.toSeconds(session.startDate)
+  override def startTimeIn(targetTimeUnit: TimeUnit): Long =
+    targetTimeUnit.convert(session.startDate, MILLISECONDS)
 
   override def toGatlingResponseTimings: ResponseTimings =
     ResponseTimings(
@@ -78,6 +78,6 @@ case class COAffectedResponseTime(startNanos: Long, endNanos: Long)
       NANOSECONDS.toMillis(startNanos),
       NANOSECONDS.toMillis(endNanos))
 
-  override def startTimeInSeconds: Long =
-    TimeUnit.NANOSECONDS.toSeconds(startNanos)
+  override def startTimeIn(targetTimeUnit: TimeUnit): Long =
+    targetTimeUnit.convert(startNanos, NANOSECONDS)
 }

--- a/src/test/scala/com/datastax/gatling/plugin/utils/ResponseTimeSpec.scala
+++ b/src/test/scala/com/datastax/gatling/plugin/utils/ResponseTimeSpec.scala
@@ -20,7 +20,7 @@ class ResponseTimeSpec extends BaseSimulationSpec {
         timingSource.currentTimeNanos().andReturn(123456789)
       }
       whenExecuting(timingSource) {
-        ResponseTime(session, timingSource).latencyIn(NANOSECONDS) shouldBe 456789
+        GatlingResponseTime(session, timingSource).latencyIn(NANOSECONDS) shouldBe 456789
       }
     }
 
@@ -32,7 +32,7 @@ class ResponseTimeSpec extends BaseSimulationSpec {
         timingSource.currentTimeNanos().andReturn(0)
       }
       whenExecuting(timingSource) {
-        ResponseTime(session, timingSource).startTimeInSeconds shouldBe 44
+        GatlingResponseTime(session, timingSource).startTimeInSeconds shouldBe 44
       }
     }
 
@@ -42,7 +42,7 @@ class ResponseTimeSpec extends BaseSimulationSpec {
         timingSource.currentTimeNanos().andReturn(444666888)
       }
       whenExecuting(timingSource) {
-        val rt = ResponseTime(session, timingSource).toGatlingResponseTimings
+        val rt = GatlingResponseTime(session, timingSource).toGatlingResponseTimings
         rt.startTimestamp shouldBe 111
         rt.endTimestamp shouldBe 444
       }

--- a/src/test/scala/com/datastax/gatling/plugin/utils/ResponseTimeSpec.scala
+++ b/src/test/scala/com/datastax/gatling/plugin/utils/ResponseTimeSpec.scala
@@ -1,6 +1,6 @@
 package com.datastax.gatling.plugin.utils
 
-import java.util.concurrent.TimeUnit.NANOSECONDS
+import java.util.concurrent.TimeUnit.{NANOSECONDS, SECONDS}
 
 import com.datastax.gatling.plugin.base.BaseSimulationSpec
 import io.gatling.core.session.Session
@@ -32,7 +32,7 @@ class ResponseTimeSpec extends BaseSimulationSpec {
         timingSource.currentTimeNanos().andReturn(0)
       }
       whenExecuting(timingSource) {
-        GatlingResponseTime(session, timingSource).startTimeInSeconds shouldBe 44
+        GatlingResponseTime(session, timingSource).startTimeIn(SECONDS) shouldBe 44
       }
     }
 


### PR DESCRIPTION
With the recent CO fix, some simulations that rely on Gatling loops (`asLongAs`) and `atOnceUsers` injection broke.  They are cases where we want to get data loaded as fast as possible, but at the expense of unmeasurable latency.

In these cases, there is no predictable throughput.  It is not possible to compensate for coordinated omission.  The CO fix resulted in taking the Gatling user creation time as the send time for every single request.  The maximum allowed latency in `dse-plugin.config` was exceeded and uncaught exceptions killed the plugin threads.

A few other changes will be needed:
* Add some failsafe mechanism that catch exceptions but does not kill threads, in case other errors happen
* Optionally reintroduce CO if the user explicitly requests it, even though I really don't like that idea
* Contribute the HDR code to Gatling so that we do not have to measure latency ourselves, as these corner cases are already handled in gatling