### PR TITLE
Update dse-java-driver-core and dse-java-driver-graph dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,8 +4,8 @@ val gatlingVersion = "2.3.0"
 
 scalacOptions += "-target:jvm-1.8"
 
-libraryDependencies += "com.datastax.dse"             %  "dse-java-driver-core"     % "1.6.7"
-libraryDependencies += "com.datastax.dse"             %  "dse-java-driver-graph"    % "1.6.7"
+libraryDependencies += "com.datastax.dse"             %  "dse-java-driver-core"     % "1.6.8"
+libraryDependencies += "com.datastax.dse"             %  "dse-java-driver-graph"    % "1.6.8"
 libraryDependencies += "com.github.nscala-time"       %% "nscala-time"              % "2.18.0"
 libraryDependencies += "com.fasterxml.jackson.module" %% "jackson-module-scala"     % "2.9.1"
 libraryDependencies += "org.hdrhistogram"             %  "HdrHistogram"             % "2.1.10"


### PR DESCRIPTION
Using the **1.6.7** version of the drivers was raising the following error:

```
11:45:05.867 [WARN ] c.d.d.c.NettyUtil - Found Netty's native epoll transport, but not running on linux-based operating system. Using NIO instead.
Exception in thread "main" com.datastax.driver.core.exceptions.UnsupportedFeatureException: Unsupported feature with the native protocol DSE_V1 (which is currently in use): Statement uses keyspace 'load_example' which is not the same as the session keyspace 'null'.
	at com.datastax.driver.core.exceptions.UnsupportedFeatureException.copy(UnsupportedFeatureException.java:37)
	at com.datastax.driver.core.exceptions.UnsupportedFeatureException.copy(UnsupportedFeatureException.java:15)
	at com.datastax.driver.core.DriverThrowables.propagateCause(DriverThrowables.java:28)
```

This is related to: https://datastax-oss.atlassian.net/browse/JAVA-1888

On July 2nd there was a new release, 1.6.8, changed the dependency and now the **galting-plugin**->**gatling-dse-simcatalog** compile and run the sample tests without issues:

```
./gatling-dse-sims run WriteOrderSimulation
12:00:53.894 [DEBUG] c.d.g.s.l.Cassandra - Username and password set in configs using to connect to nodes
12:00:53.901 [DEBUG] c.d.g.s.l.Cassandra - Using LOCAL_QUORUM as default consistency
12:00:53.903 [DEBUG] c.d.g.s.l.Cassandra - Using LOCAL_SERIAL as serial consistency
12:00:53.926 [DEBUG] c.d.g.s.l.Cassandra - dcName found in configs, setting connection to TokenAware(DCAwareRR) w/ dc = dc1
12:00:54.276 [WARN ] c.d.d.c.NettyUtil - Found Netty's native epoll transport, but not running on linux-based operating system. Using NIO instead.
12:00:55.056 [DEBUG] c.d.g.s.c.LoadGenerator$ - Building rampUpToConstant load for scenario: OrderWrite. Ramp time: 10 seconds, Constant Time: 20 seconds, Users: 10
Simulation sims.examples.cql.orders.WriteOrderSimulation started...
```