### PR TITLE
Exclude feeder from service time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 import scala.sys.process._
 
-val gatlingVersion = "2.3.0"
+val gatlingVersion = "2.3.1"
 
 scalacOptions += "-target:jvm-1.8"
 


### PR DESCRIPTION
This PR makes sure that the feeder generation time is not included in the measured latency when the plugin is configured to measure service time.  It also adds a log that confirms which time is being measured for a given scenario.

