### PR TITLE
fixed hdr timestamps when using atOnceUsers() with -Dgatling.dse.plugin.measure_service_time

### DIFF
--- a/src/main/scala/com/datastax/gatling/plugin/utils/ResponseTime.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/utils/ResponseTime.scala
@@ -79,5 +79,5 @@ case class COAffectedResponseTime(startNanos: Long, endNanos: Long)
       NANOSECONDS.toMillis(endNanos))
 
   override def startTimeIn(targetTimeUnit: TimeUnit): Long =
-    targetTimeUnit.convert(startNanos, NANOSECONDS)
+    targetTimeUnit.convert(startNanos, MILLISECONDS)
 }


### PR DESCRIPTION
problem: hdr timestamps were wrong:
```
$ head -n 10 target/gatling/edgeinsertworkload-1542123215374/hgrms/tags/Insert_edges_int_ok.hgrm 
#[Logged with Gatling DSE Plugin v1.3.0]
#[Histogram log format version 1.3]
#[StartTime: 59448.011 (seconds since epoch), Thu Jan 01 10:30:48 CST 1970]
"StartTimestamp","Interval_Length","Interval_Max","Interval_Compressed_Histogram"
59447.000,1.000,349.962,HISTFAAAADJ42pNpmSzMwMAgyAABzFCaEYi7N50sYLD/ABHYvomJiZepmImTqZ2RSZCJgQkAz3oHnA==
59448.000,1.000,262.144,HISTFAAAAIp42i2MzQnCQBCFJ9/OuoRlCRI8BARLsIScrMQGLMKbiKCd2IWkBJvw4lnfkjxmeMz7me350ZvZ3WaEhRvt5fk62fiZhd8Nomc8iiIEp4DVSeCYh+UUMrQolNzclA+yE6GaWXpamSvlLbVbFOuoSi9O7Bh8YM/IRhV9FhcOdBz5wnXNu2GCPzryDao=
...
```

i noticed that GatlingResponseTime.startTimeIn was in ms: https://github.com/xytxytxyt/gatling-dse-plugin/blob/2cbfe3ebbf286aec13cd0ba019615916f26dc211/src/main/scala/com/datastax/gatling/plugin/utils/ResponseTime.scala#L57 so i updated COAffectedResponseTime.startTimeIn to be the same and it seemed to fix the problem

after fix:
```
#[Logged with Gatling DSE Plugin v1.3.0]
#[Histogram log format version 1.3]
#[StartTime: 71788693586.964 (seconds since epoch), Fri Nov 22 09:46:26 CST 4244]
"StartTimestamp","Interval_Length","Interval_Max","Interval_Compressed_Histogram"
71788605858.000,1.000,304.873,HISTFAAAACV42pNpmSzMwMDAwgABzFCaEYi7N50sYLD/ABGYvImJCQBvPwY9
71788605859.000,1.000,272.105,HISTFAAAACV42pNpmSzMwMDAwgABzFCaEYi7N50sYLD/ABGYuYGJCQBvUQZB
```