### PR TITLE
fixed hdr timestamps when using atOnceUsers() with -Dgatling.dse.plugin.measure_service_time

### DIFF
--- a/src/main/scala/com/datastax/gatling/plugin/request/CqlRequestAction.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/request/CqlRequestAction.scala
@@ -10,6 +10,7 @@ import java.lang.Boolean
 import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit.MICROSECONDS
+import java.time.Instant
 
 import akka.actor.ActorSystem
 import com.datastax.gatling.plugin.DseProtocol
@@ -65,7 +66,8 @@ class CqlRequestAction(val name: String,
     val enableCO = Boolean.getBoolean("gatling.dse.plugin.measure_service_time")
     val responseTimeBuilder: ResponseTimeBuilder = if (enableCO) {
       // The throughput checker is useless in CO affected scenarios since throughput is not known in advance
-      COAffectedResponseTime.startingAt(System.nanoTime())
+      val now = Instant.now()
+      COAffectedResponseTime.startingAt(now.getEpochSecond()*1000000000 + now.getNano())
     } else {
       ThroughputVerifier.checkForGatlingOverloading(session, gatlingTimingSource)
       GatlingResponseTime.startedByGatling(session, gatlingTimingSource)

--- a/src/main/scala/com/datastax/gatling/plugin/request/GraphRequestAction.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/request/GraphRequestAction.scala
@@ -10,6 +10,7 @@ import java.lang.Boolean
 import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit.MICROSECONDS
+import java.time.Instant
 
 import akka.actor.ActorSystem
 import com.datastax.gatling.plugin.DseProtocol
@@ -64,7 +65,8 @@ class GraphRequestAction(val name: String,
     val enableCO = Boolean.getBoolean("gatling.dse.plugin.measure_service_time")
     val responseTimeBuilder: ResponseTimeBuilder = if (enableCO) {
       // The throughput checker is useless in CO affected scenarios since throughput is not known in advance
-      COAffectedResponseTime.startingAt(System.nanoTime())
+      val now = Instant.now()
+      COAffectedResponseTime.startingAt(now.getEpochSecond()*1000000000 + now.getNano())
     } else {
       ThroughputVerifier.checkForGatlingOverloading(session, gatlingTimingSource)
       GatlingResponseTime.startedByGatling(session, gatlingTimingSource)

--- a/src/main/scala/com/datastax/gatling/plugin/utils/ResponseTime.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/utils/ResponseTime.scala
@@ -8,6 +8,7 @@ package com.datastax.gatling.plugin.utils
 
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeUnit.{MILLISECONDS, NANOSECONDS}
+import java.time.Instant
 
 import io.gatling.commons.util.ClockSingleton
 import io.gatling.core.Predef.Session
@@ -65,7 +66,10 @@ case class GatlingResponseTime(session: Session, timingSource: TimingSource)
 
 object COAffectedResponseTime {
   def startingAt(startNanos: Long): ResponseTimeBuilder =
-    () => COAffectedResponseTime(startNanos, System.nanoTime())
+    () => {
+      val now = Instant.now()
+      COAffectedResponseTime(startNanos, now.getEpochSecond()*1000000000 + now.getNano())
+    }
 }
 
 case class COAffectedResponseTime(startNanos: Long, endNanos: Long)


### PR DESCRIPTION
problem: hdr timestamps were wrong:
```
$ head -n 10 target/gatling/edgeinsertworkload-1542123215374/hgrms/tags/Insert_edges_int_ok.hgrm 
#[Logged with Gatling DSE Plugin v1.3.0]
#[Histogram log format version 1.3]
#[StartTime: 59448.011 (seconds since epoch), Thu Jan 01 10:30:48 CST 1970]
"StartTimestamp","Interval_Length","Interval_Max","Interval_Compressed_Histogram"
59447.000,1.000,349.962,HISTFAAAADJ42pNpmSzMwMAgyAABzFCaEYi7N50sYLD/ABHYvomJiZepmImTqZ2RSZCJgQkAz3oHnA==
59448.000,1.000,262.144,HISTFAAAAIp42i2MzQnCQBCFJ9/OuoRlCRI8BARLsIScrMQGLMKbiKCd2IWkBJvw4lnfkjxmeMz7me350ZvZ3WaEhRvt5fk62fiZhd8Nomc8iiIEp4DVSeCYh+UUMrQolNzclA+yE6GaWXpamSvlLbVbFOuoSi9O7Bh8YM/IRhV9FhcOdBz5wnXNu2GCPzryDao=
...
```

the issue was that `System.nanoTime()` was being unsuitably used as an absolute time in https://github.com/datastax/gatling-dse-plugin/blob/8dfa8179733cc908e5f47c08e644476fbe13938c/src/main/scala/com/datastax/gatling/plugin/metrics/HistogramLogger.scala#L189

after the fix:
```
#[Logged with Gatling DSE Plugin v1.3.0]
#[Histogram log format version 1.3]
#[StartTime: 1542140832.990 (seconds since epoch), Tue Nov 13 14:27:12 CST 2018]
"StartTimestamp","Interval_Length","Interval_Max","Interval_Compressed_Histogram"
1542140832.000,1.000,264.110,HISTFAAAADV42pNpmSzMwMAgygABzFCaEYi7N50sYLD/ABE4upiJiZvpIyNTJxuLNJC1kpmJlwUA+qEI7g==
1542140833.000,1.000,265.028,HISTFAAAAHt42pNpmSzMwMCQzwABzFCaEYi7N50sYLD/ABGYOYGJSZpJlkWaSZoDRFuCeGzSPNJQ0XIma6bXTGBhaxYIlmYrZ5JlCmcqZwEqYNnMyPSckUmahZupnZFlKyOTJZM2Ey8TNxDPZ2Kaygg0YCITkyZTJlB4LRMTAMTHFEY=
...
```