### PR TITLE
Handling exceptions from user-supplied lambdas in GraphRequestAction

### DIFF
--- a/src/main/scala/com/datastax/gatling/plugin/request/GraphRequestAction.scala
+++ b/src/main/scala/com/datastax/gatling/plugin/request/GraphRequestAction.scala
@@ -12,12 +12,14 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit.MICROSECONDS
 
 import akka.actor.ActorSystem
+import com.datastax.driver.dse.graph.GraphStatement
 import com.datastax.gatling.plugin.DseProtocol
 import com.datastax.gatling.plugin.metrics.MetricsLogger
 import com.datastax.gatling.plugin.model.DseGraphAttributes
 import com.datastax.gatling.plugin.response.GraphResponseHandler
 import com.datastax.gatling.plugin.utils._
 import io.gatling.commons.stats.KO
+import io.gatling.commons.validation.Validation
 import io.gatling.core.action.{Action, ExitableAction}
 import io.gatling.core.session.Session
 import io.gatling.core.stats.StatsEngine
@@ -69,7 +71,18 @@ class GraphRequestAction(val name: String,
       ThroughputVerifier.checkForGatlingOverloading(session, gatlingTimingSource)
       GatlingResponseTime.startedByGatling(session, gatlingTimingSource)
     }
-    val stmt = dseAttributes.statement.buildFromSession(session)
+
+    // Attempt to generate a graph statement from our parameters, propagating any uncaught exceptions after
+    // continuing the chain with a failed session
+    val stmt: Validation[GraphStatement] = try {
+      dseAttributes.statement.buildFromSession(session)
+    } catch {
+      case e: Throwable => {
+        logger.error("Failed to generate GraphStatement", e)
+        next ! session.markAsFailed
+        throw e
+      }
+    }
 
     stmt.onFailure(err => {
       val responseTime = responseTimeBuilder.build()


### PR DESCRIPTION
GraphRequestAction implements ChainableAction, but there's a specific case where it won't pass the Gatling session forward to the next action in the chain, hanging Gatling. The specific case is when the user supplies a lambda to delay generation of the GraphStatement until GRA is already inside `sendQuery` on its own fixed-sized threadpool, and then that lambda throws an exception.

Please feel free to be vicious with the PR review, as I'm well outside my starting point on this issue's debugging trajectory, and not intimately familiar with the components I'm touching here.

The DSP issue for which this PR's branch is named is sort of tangential to the PR, since the issue involves multiple potential problems in different component.s